### PR TITLE
补上一句，让看文档的朋友少踩一个坑

### DIFF
--- a/content/zh-cn/docs/prologue/installation/redhat.md
+++ b/content/zh-cn/docs/prologue/installation/redhat.md
@@ -28,6 +28,7 @@ sudo dnf install v2ray-core
 ```
 
 > 如需Xray内核请参考: <https://github.com/XTLS/Xray-install>
+> 请先安装2rayA之后在使用xray-install.sh的脚本安装xray核心.顺序错了会导致机器网络故障无法启动V2rayA 
 
 ### 安装 v2rayA
 


### PR DESCRIPTION
先用脚本安装了xray核心之后，不配置xray  网络会出现问题。 会让V2rayA程序监听不到apple.com的http响应，从而无法正常启动。

https://github.com/v2rayA/v2rayA/blob/b2c017e8649302ecf6e1e48c5003ba89f949881a/service/pre.go#L181-L188