### PR TITLE
update: docker run with --privileged is necessary

### DIFF
--- a/content/zh-cn/docs/prologue/installation/docker.md
+++ b/content/zh-cn/docs/prologue/installation/docker.md
@@ -41,6 +41,7 @@ docker run -d \
   -p 2017:2017 \
   -p 20170-20172:20170-20172 \
   --restart=always \
+  --privileged \
   --name v2raya \
   -v /etc/v2raya:/etc/v2raya \
   mzz2017/v2raya


### PR DESCRIPTION
I think it is necessary to run this image with --privileged.
without --privileged, throw a permission denied error when starting up proxy.
```
failed to start v2ray-core: not support "redirect" mode of transparent proxy: ExecCommands: iptables-legacy -w 2 -t nat -N V2RAY iptables v1.8.7 (legacy): can't initialize iptables table `nat': Permission denied (you must be root) Perhaps iptables or your kernel needs to be upgraded. : exit status 3
```