### PR TITLE
fix(prologue/installation/docker.md): use readonly mount

### DIFF
--- a/content/en/docs/prologue/installation/docker.md
+++ b/content/en/docs/prologue/installation/docker.md
@@ -25,8 +25,8 @@ docker run -d \
   --network=host \
   --name v2raya \
   -e V2RAYA_ADDRESS=0.0.0.0:2017 \
-      -v /lib/modules:/lib/modules \
-  -v /etc/resolv.conf:/etc/resolv.conf \
+  -v /lib/modules:/lib/modules:ro \
+  -v /etc/resolv.conf:/etc/resolv.conf:ro \
   -v /etc/v2raya:/etc/v2raya \
   mzz2017/v2raya
 ```

--- a/content/en/docs/prologue/installation/docker.md
+++ b/content/en/docs/prologue/installation/docker.md
@@ -26,7 +26,7 @@ docker run -d \
   --name v2raya \
   -e V2RAYA_ADDRESS=0.0.0.0:2017 \
   -v /lib/modules:/lib/modules:ro \
-  -v /etc/resolv.conf:/etc/resolv.conf:ro \
+  -v /etc/resolv.conf:/etc/resolv.conf \
   -v /etc/v2raya:/etc/v2raya \
   mzz2017/v2raya
 ```

--- a/content/zh-cn/docs/prologue/installation/docker.md
+++ b/content/zh-cn/docs/prologue/installation/docker.md
@@ -25,8 +25,8 @@ docker run -d \
   --network=host \
   --name v2raya \
   -e V2RAYA_ADDRESS=0.0.0.0:2017 \
-      -v /lib/modules:/lib/modules \
-  -v /etc/resolv.conf:/etc/resolv.conf \
+  -v /lib/modules:/lib/modules:ro \
+  -v /etc/resolv.conf:/etc/resolv.conf:ro \
   -v /etc/v2raya:/etc/v2raya \
   mzz2017/v2raya
 ```

--- a/content/zh-cn/docs/prologue/installation/docker.md
+++ b/content/zh-cn/docs/prologue/installation/docker.md
@@ -26,7 +26,7 @@ docker run -d \
   --name v2raya \
   -e V2RAYA_ADDRESS=0.0.0.0:2017 \
   -v /lib/modules:/lib/modules:ro \
-  -v /etc/resolv.conf:/etc/resolv.conf:ro \
+  -v /etc/resolv.conf:/etc/resolv.conf \
   -v /etc/v2raya:/etc/v2raya \
   mzz2017/v2raya
 ```


### PR DESCRIPTION
For system file mounts, readonly mode can be used.