### PR TITLE
 ci: migrate page deployment to official github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,10 +45,26 @@ jobs:
       if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
       run: yarn build
 
-    - name: Deploy
-      uses: JamesIves/github-pages-deploy-action@4.0.0
-      if: ${{ github.ref == 'refs/heads/main' }}
+    - name: Setup Pages
+      if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+      id: pages
+      uses: actions/configure-pages@v2
+    
+    - name: Upload artifact
+      if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+      uses: actions/upload-pages-artifact@v1
       with:
-        branch: pages
-        folder: public
-        clean: true
+        path: ./public
+
+  # Deployment job
+  deploy:
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
GitHub now has official GitHub Pages Action

https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/

