### PR TITLE
fix: add additional iptables description

### DIFF
--- a/content/zh-cn/docs/prologue/installation/debian.md
+++ b/content/zh-cn/docs/prologue/installation/debian.md
@@ -82,7 +82,15 @@ sudo apt install /path/download/installer_debian_xxx_vxxx.deb ### 自行替换 d
 
 ## 切换 iptables 为 iptables-nft
 
-对于 Debian11 用户来说，iptables 已被弃用。使用 nftables 作为 iptables 的后端以进行适配：
+对于 Debian11 用户来说，iptables 已被弃用。安装 iptables 后，Debian 会自动设置使用 iptables-nft 作为后端。
+
+安装 iptables，自动启用 iptables-nft：
+
+```bash
+apt install iptables
+```
+
+也可以手动设置使用 nftables 作为 iptables 的后端以进行适配：
 
 ```bash
 update-alternatives --set iptables /usr/sbin/iptables-nft


### PR DESCRIPTION
Debian 安装相关部分原说明 "iptables 已被弃用“ 易产生一定的误导性，导致部分 Debian 用户不安装 iptables 包，则后续设置替替代条目将不可用。事实上，iptables 依然需要安装，其包含了使用 nftlib 相关库的 iptables-nft 后端，而 Debian 的 nftables 包只包含 nftables 可执行二进制程序。因此做了相关修改，补充必须要先安装 iptables 的说明 （Debian 的 nftables 包本身是作为 iptables 的 **可选依赖** 推荐安装的）。