### PR TITLE
Update debian.md to enhance security

### DIFF
--- a/content/zh-cn/docs/prologue/installation/debian.md
+++ b/content/zh-cn/docs/prologue/installation/debian.md
@@ -45,13 +45,13 @@ sudo systemctl disable v2ray --now
 #### 添加公钥
 
 ```bash
-wget -qO - https://apt.v2raya.org/key/public-key.asc | sudo tee /etc/apt/trusted.gpg.d/v2raya.asc
+wget -qO - https://apt.v2raya.org/key/public-key.asc | sudo tee /etc/apt/keyrings/v2raya.asc
 ```
 
 #### 添加 V2RayA 软件源
 
 ```bash
-echo "deb https://apt.v2raya.org/ v2raya main" | sudo tee /etc/apt/sources.list.d/v2raya.list
+echo "deb [signed-by=/etc/apt/keyrings/v2raya.asc] https://apt.v2raya.org/ v2raya main" | sudo tee /etc/apt/sources.list.d/v2raya.list
 sudo apt update
 ```
 


### PR DESCRIPTION
Limit the GPG key scope to v2raya repository only. Refer:
https://askubuntu.com/questions/1286545/what-commands-exactly-should-replace-the-deprecated-apt-key