### PR TITLE
docs(help): add Chinese documentation for manually building v2rayA

### DIFF
--- a/content/zh-cn/docs/advanced-application/nginx-prefix-deploy.md
+++ b/content/zh-cn/docs/advanced-application/nginx-prefix-deploy.md
@@ -27,17 +27,17 @@ http {
     listen 8080;
     server_name example.com;
     location ^~ /v2raya {
-      proxy_redirect off;
-      proxy_set_header Accept-Encoding "";
+      proxy_pass http://bla:2017/;
+      proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection $connection_upgrade;
-      rewrite ^/v2raya$ / break;
-      rewrite ^/v2raya/(.*)$ /$1 break;
-      sub_filter '\"static/' '\"/v2raya/static/';
-      sub_filter '\"/api' '\"/v2raya/api';
+      proxy_set_header Connection 'upgrade';
+      proxy_set_header Host $host;
+      proxy_cache_bypass $http_upgrade;
+
+      proxy_redirect http://bla:2017/ /v2rayb/;
+      sub_filter 'href="/' 'href="/v2rayb/';
+      sub_filter 'src="/' 'src="/v2rayb/';
       sub_filter_once off;
-      sub_filter_types application/javascript;
-      proxy_pass http://127.0.0.1:2017;
     }
   }
 }

--- a/content/zh-cn/docs/help/how-to-build.md
+++ b/content/zh-cn/docs/help/how-to-build.md
@@ -16,7 +16,7 @@ images: []
 
 ## 准备构建环境
 
-确保你的系统上安装了 yarn、nodejs、git 和 golang。
+确保你的系统上安装了 `yarn`、`nodejs`、`git` 和 `golang`。
 
 ### Windows
 
@@ -106,4 +106,54 @@ PowerShell 脚本可在所有主流操作系统上运行，包括 Windows、Linu
 
 ## 手动构建 v2rayA
 
-PR WELCOME
+打开终端，`cd` 到 v2rayA 源代码所在路径。
+
+v2rayA 的整个服务端实际上是由前端页面和后端服务组成的，但前端页面的编译是独立于后端服务的，所以我们需要先编译前端页面后才可以开始服务端的编译。
+
+### 前端页面编译
+
+v2rayA 源代码所在路径的 `gui` 文件夹里存放着前端页面，如果您只是需要对前端进行修改，且您的后端目前正常运行的话，请运行如下命令进行前端的预览：
+
+```bash
+# 切换到 gui 文件夹
+cd gui
+# 安装依赖
+yarn
+# 启动预览
+yarn serve
+```
+
+预览页面的默认地址是 <http://localhost:8081/>，正常第一次预览打开后会出现如下提示：
+
+- _未在 http://localhost:8081 检测到 v2rayA 服务端，请确定 v2rayA 正常运行_
+- _您是否需要调整服务端地址？_
+
+这时候我们需要点击 _您是否需要调整服务端地址？_ 右边的 _是_ 按钮来进行服务端地址配置，填写您的服务端地址即可，默认的服务端地址为 <http://localhost:2017/>，实际情况请根据您正在使用的服务端的配置来进行编写，但请确保您的服务端已经启动且正常运行。
+
+确保前端页面可以正常预览后，您可以在终端输入 `yarn build` 来进行前端的构建。
+
+默认构建文件会生成在 v2rayA 源代码所在路径下的 `web` 文件夹中，如果您需要切换编译文件存放的地址，请在编译之前设定环境变量 `OUTPUT_DIR` 的值，具体命令如下：
+
+- Linux: `OUTPUT_DIR=<您指定的绝对路径> yarn build`
+- Windows: `$env:OUTPUT_DIR = <您指定的绝对路径> && yarn build`
+
+编译完成后你就会在 `OUTPUT_DIR` 目录下看到编译后的文件。
+
+### 服务端编译
+
+v2rayA 源代码所在路径的 `server` 文件夹里存放着服务端代码。
+
+为了编译服务端，我们需要在前端页面编译时将环境变量 `OUTPUT_DIR` 指定为 v2rayA 源代码所在路径下 `service/server/router/web` 文件夹的绝对路径，后这您可以在编译完成后手动将 `web` 文件夹移动过去。
+
+随后在终端运行如下命令进行服务端的编译：
+
+```sh
+# 切换到 server 文件夹
+cd server
+# 编译服务端
+go build -o v2raya
+```
+
+编译完成后会在 `server` 文件夹下生成对应的可执行文件 `v2rayA`，同样的，您可以使用 `-o` 参数来指定编译后的文件名及路径。
+
+值得注意的是，在实际的生产环境中，构建的时候设定了诸如 `CGO_ENABLED=0` 等参数用来优化编译，完整的编译参数可以查看 [build.sh](https://github.com/v2rayA/v2rayA/blob/main/build.sh#L16) 及 [build-in-pwsh.ps1](https://github.com/v2rayA/v2rayA/blob/main/build-in-pwsh.ps1#L51C1-L53) 中的内容。


### PR DESCRIPTION
Add Chinese documentation for manually building v2rayA.

The specific compilation parameters are not introduced in detail, but users are directed to view the automatic build script.

Code formatting using Prettier.