### PR TITLE
Update linux.md

### DIFF
--- a/content/zh-cn/docs/prologue/installation/linux.md
+++ b/content/zh-cn/docs/prologue/installation/linux.md
@@ -31,13 +31,13 @@ Snap 包的打包详情可以[在 GitHub 上](https://github.com/v2rayA/v2rayA-s
 与 v2ray core 一起安装：
 
 ```sh
-sudo sh -c "$(wget -qO- https://hubmirror.v2raya.org/v2rayA/v2rayA-installer/raw/main/installer.sh)" @ --with-v2ray
+sudo sh -c "$(wget -qO- https://github.com/v2rayA/v2rayA-installer/raw/main/installer.sh)" @ --with-v2ray
 ```
 
 与 xray core 一起安装：
 
 ```sh
-sudo sh -c "$(wget -qO- https://hubmirror.v2raya.org/v2rayA/v2rayA-installer/raw/main/installer.sh)" @ --with-xray
+sudo sh -c "$(wget -qO- https://github.com/v2rayA/v2rayA-installer/raw/main/installer.sh)" @ --with-xray
 ```
 
 如果你更倾向于使用 `curl` 而不是 `wget`，那么把 `wget -qO-` 换成 `curl -Ls` 即可。


### PR DESCRIPTION
Since hubmirror is no longer available, modify the documentation for installing with scripts on Linux.

I'm not sure it's appropriate to add a jsdelivr link，but it's another option.

```sh
sudo sh -c "$(wget -qO- https://cdn.jsdelivr.net/gh/v2rayA/v2rayA-installer@raw/main/installer.sh)" @ --with-v2ray
```

```sh
sudo sh -c "$(wget -qO- https://cdn.jsdelivr.net/gh/v2rayA/v2rayA-installer@raw/main/installer.sh)" @ --with-xray
```