### PR TITLE
Update note for  Xray path details

### DIFF
--- a/content/zh-cn/docs/manual/variable-argument.md
+++ b/content/zh-cn/docs/manual/variable-argument.md
@@ -66,7 +66,9 @@ v2raya --help
    Environment="V2RAYA_V2RAY_BIN=/usr/local/bin/xray"
    ```
 
-   注意检查 Xray 的路径是否正确。
+   注意检查 Xray 的路径是否正确，部分安装方式（例如AUR中的[xray](https://aur.archlinux.org/packages/xray)或[xray-bin](https://aur.archlinux.org/packages/xray-bin)）的xray可执行文件实际上是在 `/usr/bin/xray` 而非[xray-install](https://github.com/XTLS/Xray-install)的 `/usr/local/bin/xray` 。
+
+   请以具体安装方式的安装脚本（如PKGBUILD）所指定的目录为准。
 
 2. 重载服务：
 


### PR DESCRIPTION
Updated the note of Xray executable path for different installation methods.

The additional xray executable path of  `/usr/bin/xray` from AUR PKGBUILD:

- In the line 46 of [xray](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=xray) PKGBUILD, `/etc/xray` is a empty folder so we can not consider it.
- In the line 71 of [xray-bin](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=xray-bin), its format similar to [xray-install](https://github.com/XTLS/Xray-install).